### PR TITLE
Refactor code to eliminate O(n) hard-coding.

### DIFF
--- a/haddock/haddock.py
+++ b/haddock/haddock.py
@@ -1,27 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#import sys
-#reload(sys)
-#sys.setdefaultencoding("utf-8")
-
 import os
 import random
 from io import open
 
-curses_en = os.path.join(os.path.dirname(__file__), "curses_en.txt")
-curses_de = os.path.join(os.path.dirname(__file__), "curses_de.txt")
-curses_fr = os.path.join(os.path.dirname(__file__), "curses_fr.txt")
-
-file_en = open(curses_en, encoding="utf-8").readlines()
-file_de = open(curses_de, encoding="utf-8").readlines()
-file_fr = open(curses_fr, encoding="utf-8").readlines()
-
 def curse(lang="en"):
+    if lang not in curses:
+        try:
+            filename = os.path.join(os.path.dirname(__file__), 'curses_%s.txt' % lang)
+            with open(filename, encoding='utf-8') as f:
+                curses[lang] = [c.strip() for c in f]
+        except IOError:
+            lang = 'en'
+    return random.choice(curses[lang])
 
-	if lang=="de":
-		return random.choice(file_de).strip()
-	elif lang=="fr":
-		return random.choice(file_fr).strip()		
-	else:
-		return random.choice(file_en).strip()
+curses = {}
+_ = curse('en')


### PR DESCRIPTION
This change removes the need to add four lines (create filename, open file, check for its selection with `if`, `return` a choice) every time a new language is added. It also waits to load each non-English language file until `curse` is called with it, rather than loading every available language immediately on import.